### PR TITLE
Add index for sorting

### DIFF
--- a/gateway/index.ts
+++ b/gateway/index.ts
@@ -73,8 +73,8 @@ import { MockTodoService } from './src/service/mock-todo-service';
                 return serTodo(todo, items);
             },
 
-            editTodoItem: async (_, { id, todoId, content, done }) => {
-                await todoService.editTodoItem(todoId, id, content, done);
+            editTodoItem: async (_, { id, todoId, content, done, index }) => {
+                await todoService.editTodoItem(todoId, id, content, done, index);
                 const item = await todoService.getTodoItem(todoId, id);
                 return serTodoItem(item);
             },

--- a/gateway/src/generated/graphql/todos.d.ts
+++ b/gateway/src/generated/graphql/todos.d.ts
@@ -50,6 +50,7 @@ export type MutationEditTodoItemArgs = {
   id: Scalars['String'];
   content?: Maybe<Scalars['String']>;
   done?: Maybe<Scalars['Boolean']>;
+  index?: Maybe<Scalars['Float']>;
 };
 
 
@@ -83,6 +84,7 @@ export type TodoItem = {
   content: Scalars['String'];
   done: Scalars['Boolean'];
   created: Scalars['String'];
+  index: Scalars['Float'];
 };
 
 export type User = {
@@ -175,6 +177,7 @@ export type ResolversTypes = {
   String: ResolverTypeWrapper<Scalars['String']>,
   TodoItem: ResolverTypeWrapper<TodoItem>,
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
+  Float: ResolverTypeWrapper<Scalars['Float']>,
   Mutation: ResolverTypeWrapper<{}>,
   User: ResolverTypeWrapper<User>,
 };
@@ -187,6 +190,7 @@ export type ResolversParentTypes = {
   String: Scalars['String'],
   TodoItem: TodoItem,
   Boolean: Scalars['Boolean'],
+  Float: Scalars['Float'],
   Mutation: {},
   User: User,
 };
@@ -211,6 +215,7 @@ export type TodoItemResolvers<ContextType = any, ParentType extends ResolversPar
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   done?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>,
   created?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  index?: Resolver<ResolversTypes['Float'], ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 

--- a/gateway/src/model/todo.ts
+++ b/gateway/src/model/todo.ts
@@ -10,4 +10,5 @@ export interface TodoItem {
     content: string;
     done: boolean;
     created: Date;
+    index: number;
 }

--- a/gateway/src/service/mock-todo-service.ts
+++ b/gateway/src/service/mock-todo-service.ts
@@ -41,7 +41,8 @@ export class MockTodoService implements TodoService {
         const currentItems = this.todoItems[todoId];
         if (currentItems === undefined) throw new Error("Unknown Todo ID")
         const id = this.newId();
-        const newItem: TodoItem = { id, todoId, content, created: new Date, done: false };
+        const index = currentItems.reduce((max, item) => item.index >= max ? max + 1 : max, 0);
+        const newItem: TodoItem = { id, todoId, content, created: new Date, done: false, index };
         this.todoItems[todoId] = [...currentItems, newItem];
         return Promise.resolve(id);
     }
@@ -55,11 +56,11 @@ export class MockTodoService implements TodoService {
         return this.getTodo(id);
     }
 
-    editTodoItem(todoId: string, id: string, content: string, done: boolean): Promise<TodoItem> {
+    editTodoItem(todoId: string, id: string, content?: string, done?: boolean, index?: number): Promise<TodoItem> {
         const items = this.todoItems[todoId];
         if (items === undefined) throw new Error("Unknown Todo ID");
         this.todoItems[todoId] = items.map(todoItem => todoItem.id === todoId
-            ? this.partialUpdate(todoItem, { content, done })
+            ? this.partialUpdate(todoItem, { content, done, index })
             : todoItem
         );
         

--- a/gateway/src/service/todo-service.ts
+++ b/gateway/src/service/todo-service.ts
@@ -16,7 +16,7 @@ export interface TodoService {
 
     editTodo(id: string, title?: string, comment?: string): Promise<Todo>
     
-    editTodoItem(todoId: string, id: string, content?: string, done?: boolean): Promise<TodoItem>
+    editTodoItem(todoId: string, id: string, content?: string, done?: boolean, index?: number): Promise<TodoItem>
 
     removeTodo(id: string): Promise<void>
 

--- a/schema/todos.graphql
+++ b/schema/todos.graphql
@@ -11,6 +11,7 @@ type TodoItem @key(fields: "id") {
     content: String!
     done: Boolean!
     created: String!
+    index: Float!
 }
 
 extend type User @key(fields: "id") {
@@ -26,7 +27,7 @@ type Mutation {
     addTodo(title: String!): Todo!
     addTodoItem(todoId: String!, content: String!): TodoItem!
     editTodo(id: String!, title: String, comment: String): Todo!
-    editTodoItem(todoId: String!, id: String!, content: String, done: Boolean): TodoItem!
+    editTodoItem(todoId: String!, id: String!, content: String, done: Boolean, index: Float): TodoItem!
     removeTodo(id: String!): Boolean
     removeTodoItem(todoId: String!, id: String!): Boolean
 }


### PR DESCRIPTION
Adds `index: Float` field for `TodoItem` in GQL and extends `editTodoItem` mutation with `index: Float` so one can use this for sorting. 

New todo items always have `max(index) + 1` so they should be sorted last.